### PR TITLE
dia2code compil on AppleClang and .idea ignoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ nbproject
 src/*/*.h
 src/*/*/*.h
 .idea
+cmake-build-debug

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 nbproject
 src/*/*.h
 src/*/*/*.h
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ nbproject
 src/*/*.h
 src/*/*/*.h
 .idea
-cmake-build-debug

--- a/extern/dia2code/src/dia2code.c
+++ b/extern/dia2code/src/dia2code.c
@@ -312,7 +312,7 @@ void    createDirectories(const char* path) {
             createDirectories(tmp);
         }
         printf("Create '%s'\n",path);
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__)
         if (mkdir(path,ACCESSPERMS) != 0) {
             return;
         }


### PR DESCRIPTION
Add Mac OS dia2code "buildability" with AppleClang compiler and .idea/ ignoring for people using Jetbrains IDEs (like CLion).