### PR TITLE
Prepare build system for Jenkins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if(BUILD_CODE_COVERAGE)
   set(test_runner "${CMAKE_CURRENT_BINARY_DIR}/run_test.sh")
   file(WRITE ${test_runner}
     "cd \"${CMAKE_CURRENT_BINARY_DIR}/test\"\n"
-    "ctest"
+    "ctest||/usr/bin/true"
     )
   # Create target for code coverage
   SETUP_TARGET_FOR_COVERAGE_LCOV(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,9 @@ if(${MACHINE_ENSEA})
   set(SFML_ROOT "/usr/lsa")
   set(CMAKE_MODULE_PATH "${SFML_ROOT}/share/SFML/cmake/Modules/" ${CMAKE_MODULE_PATH})
 endif()
-find_package(SFML 2 COMPONENTS graphics network)
+find_package(SFML 2 COMPONENTS graphics network window system)
 if(NOT ${MACHINE_ENSEA})
-  set(SFML_LIBRARIES sfml-graphics sfml-network)
+  set(SFML_LIBRARIES sfml-graphics sfml-network sfml-window sfml-system)
 endif()
 
 # Find library libmicrohttpd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ if(BUILD_CODE_COVERAGE)
     '/usr/*'
     '${PROJECT_SOURCE_DIR}/test/*'
     '${PROJECT_SOURCE_DIR}/extern/*')
+  set(COVERAGE_GCOVR_EXCLUDES
+    /usr/
+    "${PROJECT_SOURCE_DIR}/test/"
+    "${PROJECT_SOURCE_DIR}/extern/")
   # Create script to run tests for code coverage
   set(test_runner "${CMAKE_CURRENT_BINARY_DIR}/run_test.sh")
   file(WRITE ${test_runner}
@@ -60,6 +64,11 @@ if(BUILD_CODE_COVERAGE)
   # Create target for code coverage
   SETUP_TARGET_FOR_COVERAGE_LCOV(
     NAME code-coverage
+    EXECUTABLE sh ${test_runner}
+    DEPENDS ${test_runner}
+    )
+  SETUP_TARGET_FOR_COVERAGE_GCOVR_XML(
+    NAME code-coverage-gcov
     EXECUTABLE sh ${test_runner}
     DEPENDS ${test_runner}
     )

--- a/cmake/GenerateDiaHeader.cmake
+++ b/cmake/GenerateDiaHeader.cmake
@@ -32,6 +32,8 @@ function(generate_dia_header dia_file)
   # Custom command that generate the cpp headers and create the stamp file
   add_custom_command(
     OUTPUT ${stamp}
+    COMMAND rm -vf ${PROJECT_SOURCE_DIR}/src/*/${namespace}.h
+    COMMAND rm -vf ${PROJECT_SOURCE_DIR}/src/*/${namespace}/*.h
     COMMAND $<TARGET_FILE:dia2code> -ns ${namespace} -d ${output_dir} -t cpp ${dia_file}
     COMMAND ${CMAKE_COMMAND} -E touch ${stamp}
     DEPENDS ${dia_file}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,6 +81,7 @@ function(add_custom_test name)
   # Add dependency to build test target before code coverage
   if(BUILD_CODE_COVERAGE)
     add_dependencies(code-coverage ${target_name})
+    add_dependencies(code-coverage-gcov ${target_name})
   endif()
 endfunction()
 


### PR DESCRIPTION
- Add code coverage target to gather results using gcovr (useful for Cobertura plugin)
- Gather coverage results even when tests failed
- Fix SFML linking on some machines