### PR TITLE
Fix include directories for libraries

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -12,7 +12,7 @@ list(REMOVE_ITEM client_sources "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp")
 # Build the "client" library, add required include and link against dependencies
 add_library(${lib_client_target} STATIC ${client_sources})
 add_dependencies(${lib_client_target} generate-headers)
-target_include_directories(${lib_client_target} INTERFACE
+target_include_directories(${lib_client_target} PUBLIC
   ${CMAKE_CURRENT_SOUCE_DIR}
   ${SFML_INCLUDE_DIR}
   )

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -11,7 +11,7 @@ list(REMOVE_ITEM server_sources "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp")
 # Build the "server" library, add required include and link against dependencies
 add_library(${lib_server_target} STATIC ${server_sources} ${jsoncpp_sources})
 add_dependencies(${lib_server_target} generate-headers)
-target_include_directories(${lib_server_target} INTERFACE
+target_include_directories(${lib_server_target} PUBLIC
   ${CMAKE_CURRENT_SOUCE_DIR}
   ${jsoncpp_include_dir}
   )

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -12,7 +12,7 @@ file(GLOB_RECURSE shared_sources *.cpp)
 # Build the "shared" library and add required includes
 add_library(${lib_shared_target} STATIC ${shared_sources})
 add_dependencies(${lib_shared_target} generate-headers)
-target_include_directories(${lib_shared_target} INTERFACE
+target_include_directories(${lib_shared_target} PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
   )
 


### PR DESCRIPTION
All the libraries used to include the base source directory of the
library as INTERFACE. This is ok for importing the library and using
the headers defined inside, but this configuration does not add the
source directory of the library as include directory when compiling the
library itself. Changing the scope from INTERFACE to PUBLIC allows to
use the root directory as include source for both the compilation of
the library and the compilation of code using this library.