### PR TITLE
changed enum to enum class

### DIFF
--- a/extern/dia2code/src/generate_code_cpp.c
+++ b/extern/dia2code/src/generate_code_cpp.c
@@ -592,7 +592,7 @@ gen_decl (declaration *d)
                                                  umla->key.value);
 
     } else if (is_enum_stereo (stype)) {
-        print ("enum %s {\n", name);
+        print ("enum class %s {\n", name);
         indentlevel++;
         while (umla != NULL) {
             char *literal = umla->key.name;


### PR DESCRIPTION
enum class should be preferred to plain enum.
enum class don't pollute the namespace and cannot be converted to int.